### PR TITLE
Remove Hardcoded 5, 10 , 20 Min From No Rush Timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ForgedAlliance_base.exe
+ForgedAlliance_ext.exe
 nasm.exe
 build/
+patch.bat

--- a/ext_sector.s
+++ b/ext_sector.s
@@ -93,6 +93,7 @@ bits 32
 	; Adress const
 	_CannotQueCommandInConstruct equ 0x006EFB0E
 	_CanQueCommandInConstruct equ 0x006EFAF8
+	_EndCalculateNoRushTimerVariable equ 0x006FF3D6
 
 	; c Symbols
 		
@@ -139,7 +140,38 @@ _HOOK_ExperimentalSelect:
 align 0x8
 _HOOK_ValidateQue:
 	jmp QueLabel	
+	
+align 0x8
+_HOOK_CalculateNoRushTimerVariable:
+	jmp TimerLabel		
 ; </ Area for hooks>
+
+align 0x4
+TimerLabel:
+	sub ecx,esi
+	push ecx
+	push eax
+	pushad 
+	mov esi,0
+	mov ebx,0
+	TimerLoop:
+	push eax
+	mov eax,0xA
+	mul bx
+	mov ebx,eax
+	pop eax
+	mov edx, [ds:eax+esi]
+	sub edx,0x30
+	add bl,dl
+	inc esi
+	loop TimerLoop
+	mov eax,0x258
+	mul bx
+	mov dword [ss:ebp+0x1CC],eax
+	popad 
+	lea ecx, [ss:esp+0x70]
+	jmp _EndCalculateNoRushTimerVariable
+
 
 align 0x4
 QueLabel:

--- a/ext_sector.s
+++ b/ext_sector.s
@@ -83,9 +83,19 @@ bits 32
 	_g_CWldSession equ 0x10A6470
 
 	_g_Sim equ 0x10A63F0
+	
+	; String const
+	s_FACTORY equ 0xE19824
+	s_EXPERIMENTAL equ 0xE204B8
+	
+	; Int const
+	c_CannotQueCommandInConstruct equ 0x006EFB0E
+	c_CanQueCommandInConstruct equ 0x006EFAF8
 
 	; c Symbols
-
+		
+	_CheckCategory equ 	0x00405550
+		
 		; Imports
 		extern _print_hello_world
 		extern _ext_ValidateFocusArmyRequest
@@ -131,13 +141,15 @@ _HOOK_ValidateQue:
 
 align 0x4
 QueLabel:
-	push 0xE19824 ; FACTORY
-	jmp 0x0128B03D ; jmp to lea ecx, [ss:esp+0x44]
-	push 0xE204B8 ; EXPERIMENTAL
+	push s_FACTORY 
+	jmp .loop1 
+	.loop2:
+	push s_EXPERIMENTAL 
 	cmp dx, 2
-	jge 0x006EFB0E
+	jge c_CannotQueCommandInConstruct
+	.loop1:
 	lea ecx, [ss:esp+0x44]
-	call 0x00405550
+	call _CheckCategory
 	mov byte [ss:esp+0x36C], 0x1
 	mov ebx, 1
 	lea ecx, [ds:edi+0x8]
@@ -145,17 +157,17 @@ QueLabel:
 	mov dword [ss:esp+0x18], ebx
 	call 0x0067B050
 	test al, al
-	jne 0x006EFAF8 ; back to start
+	jne c_CanQueCommandInConstruct
 	inc dx
-	jmp 0x0128B02E ; jmp to push 0xE204B8
+	jmp .loop2 
 	
 	
 
 align 0x4
 eprLabel:
-	push 0xE204B8 ; "Experimental" String into stack. 
+	push s_EXPERIMENTAL  
 	lea ecx, [ss:esp+0x50] ; Some input param, hek knows what. Suspect unit ID
-	call 0x00405550 ; Check if unit is in category
+	call _CheckCategory 
 	mov dword [ss:esp+0x70],0x1
 	or ebx, 0x2
 	lea eax, [ss:esp+0x4C]
@@ -165,7 +177,7 @@ eprLabel:
 	; Result will be in al (first byte), and it can be either 1 or 0. 
 	test al,al
 	jne 0x008C062A ; Jumps to code that checks for "Selectable" caterogy and then follows through with action...
-	push 0xE19824  ; "Factory" String into stack. 
+	push s_FACTORY  
 	lea ecx, [ss:esp+0x50] ; repeat function call above. 
 	jmp 0x008C0603 ; Jump to code continuation. 
 

--- a/ext_sector.s
+++ b/ext_sector.s
@@ -89,8 +89,10 @@ bits 32
 	s_EXPERIMENTAL equ 0xE204B8
 	
 	; Int const
-	c_CannotQueCommandInConstruct equ 0x006EFB0E
-	c_CanQueCommandInConstruct equ 0x006EFAF8
+	
+	; Adress const
+	_CannotQueCommandInConstruct equ 0x006EFB0E
+	_CanQueCommandInConstruct equ 0x006EFAF8
 
 	; c Symbols
 		
@@ -146,7 +148,7 @@ QueLabel:
 	.loop2:
 	push s_EXPERIMENTAL 
 	cmp dx, 2
-	jge c_CannotQueCommandInConstruct
+	jge _CannotQueCommandInConstruct
 	.loop1:
 	lea ecx, [ss:esp+0x44]
 	call _CheckCategory
@@ -157,7 +159,7 @@ QueLabel:
 	mov dword [ss:esp+0x18], ebx
 	call 0x0067B050
 	test al, al
-	jne c_CanQueCommandInConstruct
+	jne _CanQueCommandInConstruct
 	inc dx
 	jmp .loop2 
 	

--- a/ext_sector.s
+++ b/ext_sector.s
@@ -93,6 +93,7 @@ bits 32
 	; Adress const
 	_CannotQueCommandInConstruct equ 0x006EFB0E
 	_CanQueCommandInConstruct equ 0x006EFAF8
+	_NeitherInCategoryInConstruct equ 0x006EFACE
 	_EndCalculateNoRushTimerVariable equ 0x006FF3D6
 
 	; c Symbols
@@ -104,6 +105,8 @@ bits 32
 		extern _ext_ValidateFocusArmyRequest
 		extern _cxx_AddCommandSourceId
 		extern _cxx_SetCommandSourceId
+		extern _sCQUEMOV
+		
 
 	global _stricmp
 
@@ -178,9 +181,14 @@ QueLabel:
 	push s_FACTORY 
 	jmp .loop1 
 	.loop2:
-	push s_EXPERIMENTAL 
-	cmp dx, 2
-	jge _CannotQueCommandInConstruct
+	push dword [ss:_sCQUEMOV]
+	mov edx, [ss:esp-0x80]
+	mov ecx, [ss:esp]
+	mov edx, [ss:edx]
+	mov ecx, [ss:ecx]
+	cmp edx, ecx
+	je _NeitherInCategoryInConstruct
+	mov dword [ss:esp+0x20], eax
 	.loop1:
 	lea ecx, [ss:esp+0x44]
 	call _CheckCategory
@@ -192,14 +200,11 @@ QueLabel:
 	call 0x0067B050
 	test al, al
 	jne _CanQueCommandInConstruct
-	inc dx
-	jmp .loop2 
-	
-	
+	jmp .loop2
 
 align 0x4
 eprLabel:
-	push s_EXPERIMENTAL  
+	push dword [ss:_sCQUEMOV] 
 	lea ecx, [ss:esp+0x50] ; Some input param, hek knows what. Suspect unit ID
 	call _CheckCategory 
 	mov dword [ss:esp+0x70],0x1

--- a/ext_sector.s
+++ b/ext_sector.s
@@ -119,7 +119,33 @@ _HOOK_CWldSession__ValidateFocusArmyRequest: ; (int)
 align 0x8
 _HOOK_ArmyGetHandicap: ; (lua_state*)
 	jmp _ArmyGetHandicap_addValidCmdSource
+
+align 0x8	
+_HOOK_ExperimentalSelect:
+	jmp eprLabel
 ; </ Area for hooks>
+
+align 0x4
+eprLabel:
+	push 0xE204B8
+	;lea ecx, ss:[esp+0x50]
+	lea ecx, [ss:esp+0x50]
+	call 0x00405550
+	;mov dword ptr ss:[esp+0x70], 0x1
+	mov dword [ss:esp+0x70],0x1
+	or ebx, 0x2
+	;lea eax,dword ptr ss:[esp+4C]
+	lea eax, [ss:esp+0x4C]
+	mov ecx,esi
+	;mov dword ptr ss:[esp+10],ebx
+	mov dword [ss:esp+0x10],ebx
+	call 0x8B97C0
+	test al,al
+	jne 0x008C062A
+	push 0xE19824
+	lea ecx, [ss:esp+0x50]
+	;lea ecx,dword ptr ss:[esp+50]
+	jmp 0x008C0603
 
 align 0x4
 _ArmyGetHandicap_addValidCmdSource:

--- a/ext_sector_foo.cpp
+++ b/ext_sector_foo.cpp
@@ -1,6 +1,8 @@
 
 #include "moho.h"
 
+const char* sCQUEMOV = "CQUEMOV";
+
 extern "C" 
 {
 	void Logf(const char* fmt, ...);

--- a/hook_ExperimentalSelect.s
+++ b/hook_ExperimentalSelect.s
@@ -1,0 +1,12 @@
+; HOOK ExperimentalSelect ROffset = 0x4C05FE
+bits 32
+
+_HOOK_ExperimentalSelect equ 0x128B018
+
+org 0x008C05FE
+
+jmp _HOOK_ExperimentalSelect
+nop
+nop
+nop
+nop

--- a/hook_FactoryOverwrite.s
+++ b/hook_FactoryOverwrite.s
@@ -1,0 +1,9 @@
+; HOOK FactoryStringOverwrite ROffset = 0x2EFAC9
+bits 32
+
+org 0x006EFAC9
+
+push 0xE204B8 ; This will disable factory to que move and give that to Experimental flag. 
+; Because factories do not use move command, they give rally points, there is no need for move. 
+; This is not necessary, but saves me from writing extra code. Still experimental, so if problems found, can be scraped :/
+

--- a/hook_FactoryOverwrite.s
+++ b/hook_FactoryOverwrite.s
@@ -1,9 +1,0 @@
-; HOOK FactoryStringOverwrite ROffset = 0x2EFAC9
-bits 32
-
-org 0x006EFAC9
-
-push 0xE204B8 ; This will disable factory to que move and give that to Experimental flag. 
-; Because factories do not use move command, they give rally points, there is no need for move. 
-; This is not necessary, but saves me from writing extra code. Still experimental, so if problems found, can be scraped :/
-

--- a/hook_NoRush.s
+++ b/hook_NoRush.s
@@ -1,0 +1,55 @@
+; HOOK ExpandNoRushTimer ROffset = 0x2FF3D1
+bits 32
+
+_HOOK_CalculateNoRushTimerVariable equ 0x0128B028
+s_Off equ 0xE2F868
+_EndTimerValidation equ 0x006FF47D
+
+org 0x006FF3D1
+
+jmp _HOOK_CalculateNoRushTimerVariable
+nop
+call 0x004059E0
+mov bl,28
+lea ecx, [ss:esp+0x10C]
+mov byte [ss:esp+0x150],bl
+call 0x009075D0
+mov ecx, [ss:esp+0x7C]
+nop 
+nop 
+push 3
+push s_Off
+push ecx
+push edi
+lea ecx, [ss:esp+0x78]
+call 0x0040A880
+test eax,eax
+je TimerIsOff
+jmp _EndTimerValidation
+TimerIsOff:
+mov dword [ss:ebp+0x1CC],0
+jmp _EndTimerValidation
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 

--- a/hook_ValidateQue.s
+++ b/hook_ValidateQue.s
@@ -1,0 +1,50 @@
+; HOOK ValidateQueAfterSelect ROffset = 0x2EFAC9
+bits 32
+
+_HOOK_ValidateQue equ 0x0128B020
+
+org 0x006EFAC9
+jmp _HOOK_ValidateQue
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+nop 
+

--- a/hook_ValidateQue.s
+++ b/hook_ValidateQue.s
@@ -2,9 +2,14 @@
 bits 32
 
 _HOOK_ValidateQue equ 0x0128B020
+_CannotQueCommandInConstruct equ 0x006EFB0E
 
 org 0x006EFAC9
 jmp _HOOK_ValidateQue
+add esp, 0x4
+xor ecx,ecx
+xor eax,eax
+jmp _CannotQueCommandInConstruct
 nop 
 nop 
 nop 
@@ -30,21 +35,5 @@ nop
 nop 
 nop 
 nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
-nop 
+nop
 

--- a/patch.py
+++ b/patch.py
@@ -96,7 +96,7 @@ def main():
 			 'hook_ArmyGetHandicap.s',
 			 'hook_Walls.s',
 			 'hook_ExperimentalSelect.s',
-			 'hook_FactoryOverwrite.s']
+			 'hook_ValidateQue.s']
 			 #,
 			 #'hook_ValidateFocusArmyRequest.s']
 

--- a/patch.py
+++ b/patch.py
@@ -96,7 +96,8 @@ def main():
 			 'hook_ArmyGetHandicap.s',
 			 'hook_Walls.s',
 			 'hook_ExperimentalSelect.s',
-			 'hook_ValidateQue.s']
+			 'hook_ValidateQue.s',
+			 'hook_NoRush.s']
 			 #,
 			 #'hook_ValidateFocusArmyRequest.s']
 

--- a/patch.py
+++ b/patch.py
@@ -94,7 +94,9 @@ def main():
 
 	hooks = ['hook_LoadSavedGame.s',
 			 'hook_ArmyGetHandicap.s',
-			 'hook_Walls.s' ]
+			 'hook_Walls.s',
+			 'hook_ExperimentalSelect.s',
+			 'hook_FactoryOverwrite.s']
 			 #,
 			 #'hook_ValidateFocusArmyRequest.s']
 


### PR DESCRIPTION
To properly test this you will have to modify some lua code. Specifically  this: 
https://github.com/FAForever/fa/blob/114ac5b534584c5ff0dcab66949abe8050205b24/lua/ui/lobby/lobbyOptions.lua#L344
-------------------------------------------------------------------------------------------------------
There is a limit though. Max value 8 bit register can hold is FFFF -> 65535 dec(millisecond) -> 1.09225 (min) -> *100 = 109.225 min is the maximum value allowed. 

This contains my other patch for selection as well, to be safe. 